### PR TITLE
Fixup Desktop KPIs

### DIFF
--- a/firefox-desktop/dashboards/desktop_kpis.dashboard.lookml
+++ b/firefox-desktop/dashboards/desktop_kpis.dashboard.lookml
@@ -53,7 +53,8 @@
         series_index: 1, show_label: true}]
     defaults_version: 1
     hidden_fields:
-    listen: {}
+    listen:
+      Date: desktop_kpis.date
     row: 23
     col: 0
     width: 24
@@ -100,7 +101,8 @@
         Pace
     defaults_version: 1
     hidden_fields: []
-    listen: {}
+    listen:
+      Date: desktop_kpis.date
     row: 14
     col: 12
     width: 12
@@ -431,7 +433,8 @@
         margin_value: mean, margin_bottom: deviation, label_position: right, color: "#000000",
         line_value: '0', label: At Forecast}]
     defaults_version: 1
-    listen: {}
+    listen:
+      Date: desktop_kpis.date
     row: 14
     col: 0
     width: 12
@@ -476,7 +479,8 @@
         Pace
       desktop_kpis.new_profiles_cumulative: Cumulative New Profiles
     defaults_version: 1
-    listen: {}
+    listen:
+      Date: desktop_kpis.date
     row: 34
     col: 12
     width: 12
@@ -531,7 +535,8 @@
       loines_desktop_new_profiles_forecast_20210119.yhat_lower: triangle
       loines_desktop_new_profiles_forecast_20210119.yhat_upper: triangle-down
     defaults_version: 1
-    listen: {}
+    listen:
+      Date: desktop_kpis.date
     row: 43
     col: 0
     width: 24
@@ -573,8 +578,24 @@
               From Forecast New Profiles Count Running}], showLabels: true, showValues: true,
         unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
     defaults_version: 1
-    listen: {}
+    listen:
+      Date: desktop_kpis.date
     row: 34
     col: 0
     width: 12
     height: 9
+  filters:
+  - name: Date
+    title: Date
+    type: field_filter
+    default_value: after 2021/01/01
+    allow_multiple_values: true
+    required: true
+    ui_config:
+      type: advanced
+      display: popover
+      options: []
+    model: firefox-desktop
+    explore: desktop_kpis
+    listens_to_filters: []
+    field: desktop_kpis.date

--- a/firefox-desktop/views/desktop_kpis.view.lkml
+++ b/firefox-desktop/views/desktop_kpis.view.lkml
@@ -2,7 +2,7 @@ view: desktop_kpis {
   derived_table: {
     sql: WITH base AS (
           SELECT
-            submission_date as date
+            TIMESTAMP(submission_date) as date
             , SUM(cdou) as cdou
             , SUM(dau) as dau
             , SUM(new_profiles) as new_profiles

--- a/firefox-desktop/views/loines_desktop_dau_forecast_20210119.view.lkml
+++ b/firefox-desktop/views/loines_desktop_dau_forecast_20210119.view.lkml
@@ -1,6 +1,13 @@
 view: loines_desktop_dau_forecast_20210119 {
-  sql_table_name: `mozdata.analysis.loines_desktop_dau_forecast_2021-01-19`
-    ;;
+  derived_table: {
+    sql:
+      SELECT
+        *
+        , SUM(dau_forecast_plus5) OVER (PARTITION BY EXTRACT(YEAR FROM ds) ORDER BY ds) AS cumulative_forecast_plus5
+      FROM `mozdata.analysis.loines_desktop_dau_forecast_2021-01-19`
+      ORDER BY 1
+      ;;
+  }
 
   dimension: date {
     type: date
@@ -22,13 +29,13 @@ view: loines_desktop_dau_forecast_20210119 {
   measure: dau_forecast_plus5 {
     type: sum
     value_format: "#,##0"
-    sql: ${TABLE}.dau_forecast_plus5 ;;
+    sql: ${TABLE}. ;;
   }
 
   measure: cumulative_forecast_plus5 {
-    type: running_total
+    type: sum
     value_format: "#,##0"
-    sql: ${dau_forecast_plus5} ;;
+    sql: ${TABLE}.cumulative_forecast_plus5 ;;
   }
 
   measure: recent_cumulative_forecast_plus5 {
@@ -41,12 +48,6 @@ view: loines_desktop_dau_forecast_20210119 {
     type: sum
     value_format: "#,##0"
     sql: ${TABLE}.dau_forecast_upper ;;
-  }
-
-  measure: dau_new_profiles_actual {
-    type: sum
-    value_format: "#,##0"
-    sql: ${TABLE}.dau_new_profiles_actual ;;
   }
 
   measure: yhat_cumulative {

--- a/firefox-desktop/views/loines_desktop_new_profiles_forecast_20210119.view.lkml
+++ b/firefox-desktop/views/loines_desktop_new_profiles_forecast_20210119.view.lkml
@@ -1,7 +1,13 @@
 view: loines_desktop_new_profiles_forecast_20210119 {
-  sql_table_name: `mozdata.analysis.loines_desktop_new_profiles_forecast_2021-01-19`
-    ;;
-
+  derived_table: {
+    sql:
+      SELECT
+        *
+        , SUM(forecast_plus5) OVER (PARTITION BY EXTRACT(YEAR FROM date) ORDER BY date) AS cumulative_new_profiles_forecast_plus5
+      FROM `mozdata.analysis.loines_desktop_new_profiles_forecast_2021-01-19`
+      ORDER BY 1
+      ;;
+  }
   dimension: date {
     type: date
     sql: ${TABLE}.date ;;
@@ -26,9 +32,9 @@ view: loines_desktop_new_profiles_forecast_20210119 {
   }
 
   measure: cumulative_new_profiles_forecast_plus5 {
-    type: running_total
+    type: sum
     value_format: "#,##0"
-    sql: ${forecast_plus5} ;;
+    sql: ${TABLE}.cumulative_new_profiles_forecast_plus5 ;;
   }
 
   measure: yhat {


### PR DESCRIPTION
This adds a hardcoded yearly cumulative forecast plus 5 (target pace) to the forecast tables. It also adds a date filter to the dashboard, which should work now. 